### PR TITLE
feat: seed user management sheets and repositories

### DIFF
--- a/backend/scripts/seedSheets.ts
+++ b/backend/scripts/seedSheets.ts
@@ -1,4 +1,6 @@
-﻿import { google, sheets_v4 } from 'googleapis';
+import bcrypt from 'bcryptjs';
+import { google, sheets_v4 } from 'googleapis';
+import { v4 as uuid } from 'uuid';
 import config from '../src/config/env';
 import logger from '../src/utils/logger';
 import { withRetry } from '../src/utils/retry';
@@ -41,7 +43,11 @@ const HEADERS: HeaderMap = {
     'ip',
     'user_agent',
     'note'
-  ]
+  ],
+  users: ['id', 'email', 'name', 'role', 'status', 'created_at', 'updated_at', 'last_login_at'],
+  user_credentials: ['user_id', 'password_hash', 'password_updated_at', 'password_needs_reset'],
+  refresh_tokens: ['id', 'user_id', 'token_hash', 'issued_at', 'expires_at', 'user_agent', 'ip', 'revoked'],
+  smtp_sends_history: ['id', 'channel_id', 'to', 'subject', 'status', 'error', 'timestamp']
 };
 
 type SheetsClient = sheets_v4.Sheets;
@@ -90,6 +96,109 @@ async function ensureSheet(
   }
 }
 
+async function getSheetRows(sheets: SheetsClient, spreadsheetId: string, tab: string): Promise<string[][]> {
+  const response = await withRetry(() =>
+    sheets.spreadsheets.values.get({
+      spreadsheetId,
+      range: `${tab}!A:Z`
+    })
+  );
+  return response.data.values ?? [];
+}
+
+async function appendRow(sheets: SheetsClient, spreadsheetId: string, tab: string, row: string[]): Promise<void> {
+  await withRetry(() =>
+    sheets.spreadsheets.values.append({
+      spreadsheetId,
+      range: `${tab}!A:Z`,
+      valueInputOption: 'RAW',
+      insertDataOption: 'INSERT_ROWS',
+      requestBody: { values: [row] }
+    })
+  );
+}
+
+async function seedAdminUser(sheets: SheetsClient, spreadsheetId: string): Promise<void> {
+  const adminPassword = process.env.ADMIN_INITIAL_PASSWORD;
+  if (!adminPassword) {
+    throw new Error('Missing required environment variable: ADMIN_INITIAL_PASSWORD');
+  }
+
+  const adminEmail = config.adminEmail;
+  const normalizedAdminEmail = adminEmail.toLowerCase();
+  const adminName = process.env.ADMIN_INITIAL_NAME || 'Administrator';
+  const now = new Date().toISOString();
+
+  const userRows = await getSheetRows(sheets, spreadsheetId, 'users');
+  const [userHeader, ...userData] = userRows.length
+    ? [userRows[0], userRows.slice(1)]
+    : [HEADERS['users'], []];
+
+  const emailIndex = userHeader.indexOf('email');
+  const idIndex = userHeader.indexOf('id');
+  const nameIndex = userHeader.indexOf('name');
+  const roleIndex = userHeader.indexOf('role');
+  const statusIndex = userHeader.indexOf('status');
+  const createdAtIndex = userHeader.indexOf('created_at');
+  const updatedAtIndex = userHeader.indexOf('updated_at');
+  const lastLoginIndex = userHeader.indexOf('last_login_at');
+
+  let adminUserId: string;
+  const existingAdminRowIndex = userData.findIndex(
+    (row) => (row[emailIndex] || '').toLowerCase() === normalizedAdminEmail
+  );
+
+  if (existingAdminRowIndex === -1) {
+    adminUserId = uuid();
+    const newRow = [adminUserId, adminEmail, adminName, 'admin', 'active', now, now, ''];
+    await appendRow(sheets, spreadsheetId, 'users', newRow);
+    logger.info({ tab: 'users', email: adminEmail }, 'Admin user created');
+  } else {
+    const existingRow = userData[existingAdminRowIndex];
+    adminUserId = existingRow[idIndex];
+    const normalizedRow = [
+      adminUserId,
+      adminEmail,
+      existingRow[nameIndex] || adminName,
+      existingRow[roleIndex] || 'admin',
+      existingRow[statusIndex] || 'active',
+      existingRow[createdAtIndex] || now,
+      existingRow[updatedAtIndex] || existingRow[createdAtIndex] || now,
+      existingRow[lastLoginIndex] || ''
+    ];
+
+    const needsUpdate = userHeader.some((_, index) => (existingRow[index] || '') !== normalizedRow[index]);
+    if (needsUpdate) {
+      const updatedSheet = [userHeader, ...userData];
+      updatedSheet[existingAdminRowIndex + 1] = normalizedRow;
+      await withRetry(() =>
+        sheets.spreadsheets.values.update({
+          spreadsheetId,
+          range: 'users!A1',
+          valueInputOption: 'RAW',
+          requestBody: { values: updatedSheet }
+        })
+      );
+      logger.info({ tab: 'users', email: adminEmail }, 'Admin user normalized');
+    }
+  }
+
+  const credentialRows = await getSheetRows(sheets, spreadsheetId, 'user_credentials');
+  const [credentialHeader, ...credentialData] = credentialRows.length
+    ? [credentialRows[0], credentialRows.slice(1)]
+    : [HEADERS['user_credentials'], []];
+
+  const userIdIndex = credentialHeader.indexOf('user_id');
+  const existingCredential = credentialData.find((row) => row[userIdIndex] === adminUserId);
+
+  if (!existingCredential) {
+    const passwordHash = await bcrypt.hash(adminPassword, 12);
+    const credentialRow = [adminUserId, passwordHash, now, 'true'];
+    await appendRow(sheets, spreadsheetId, 'user_credentials', credentialRow);
+    logger.info({ tab: 'user_credentials', email: adminEmail }, 'Admin credential created');
+  }
+}
+
 async function main(): Promise<void> {
   const credentials = JSON.parse(config.googleServiceAccountJson);
   const auth = new google.auth.JWT({
@@ -103,6 +212,8 @@ async function main(): Promise<void> {
   for (const [tab, header] of Object.entries(HEADERS)) {
     await ensureSheet(sheets, config.googleSheetsId, tab, header);
   }
+
+  await seedAdminUser(sheets, config.googleSheetsId);
 
   logger.info('Google Sheets seed completed');
 }

--- a/backend/src/domain/types.ts
+++ b/backend/src/domain/types.ts
@@ -1,4 +1,4 @@
-﻿export type CertificateStatus = 'active' | 'expired' | 'revoked';
+export type CertificateStatus = 'active' | 'expired' | 'revoked';
 
 export type ChannelType =
   | 'email_smtp'
@@ -80,12 +80,35 @@ export interface AuditLog {
   note?: string;
 }
 
+export type UserStatus = 'active' | 'inactive' | 'suspended';
+
 export interface User {
   id: string;
   email: string;
   name: string;
   role: 'admin' | 'viewer';
+  status: UserStatus;
   createdAt: string;
+  updatedAt: string;
+  lastLoginAt?: string;
+}
+
+export interface UserCredential {
+  userId: string;
+  passwordHash: string;
+  passwordUpdatedAt: string;
+  passwordNeedsReset: boolean;
+}
+
+export interface RefreshToken {
+  id: string;
+  userId: string;
+  tokenHash: string;
+  issuedAt: string;
+  expiresAt: string;
+  userAgent?: string;
+  ip?: string;
+  revoked: boolean;
 }
 
 export interface NotificationContext {

--- a/backend/src/repositories/interfaces.ts
+++ b/backend/src/repositories/interfaces.ts
@@ -1,4 +1,4 @@
-﻿import {
+import {
   AlertModel,
   AuditLog,
   Certificate,
@@ -6,7 +6,9 @@
   ChannelParam,
   ChannelSecret,
   CertificateChannelLink,
-  User
+  RefreshToken,
+  User,
+  UserCredential
 } from '../domain/types';
 
 export interface CertificateRepository {
@@ -52,7 +54,23 @@ export interface AuditLogRepository {
 }
 
 export interface UserRepository {
+  getUserById(id: string): Promise<User | null>;
   getUserByEmail(email: string): Promise<User | null>;
   createUser(user: User): Promise<void>;
+  updateUser(id: string, input: Partial<User>): Promise<User>;
+  deleteUser(id: string): Promise<void>;
   listUsers(): Promise<User[]>;
+}
+
+export interface UserCredentialsRepository {
+  getUserCredential(userId: string): Promise<UserCredential | null>;
+  saveUserCredential(credential: UserCredential): Promise<void>;
+  verifyUserPassword(userId: string, password: string): Promise<boolean>;
+}
+
+export interface RefreshTokenRepository {
+  createRefreshToken(token: RefreshToken): Promise<void>;
+  revokeRefreshToken(id: string): Promise<void>;
+  getRefreshTokenById(id: string): Promise<RefreshToken | null>;
+  listRefreshTokensByUser(userId: string): Promise<RefreshToken[]>;
 }


### PR DESCRIPTION
## Summary
- extend Google Sheets schema with users, credentials, and refresh token tabs and associated TypeScript models
- add repository methods for user CRUD, password verification, and refresh token management backed by Sheets
- enhance the seeding script to provision new tabs and bootstrap an admin account using ADMIN_INITIAL_PASSWORD

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d97761f64c8330a09432ba63dfab51