### PR TITLE
Implement repository-backed authentication with refresh rotation

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -69,7 +69,7 @@ const config: AppConfig = {
   appBaseUrl: normalizeAppBaseUrl(required(process.env.APP_BASE_URL, 'APP_BASE_URL')),
   jwtSecret: required(process.env.JWT_SECRET, 'JWT_SECRET'),
   jwtExpiresIn: process.env.JWT_EXPIRES_IN || '15m',
-  jwtRefreshExpiresIn: process.env.JWT_REFRESH_EXPIRES_IN || '7d',
+  jwtRefreshExpiresIn: process.env.JWT_REFRESH_EXPIRES_IN || '14d',
   adminEmail: required(process.env.ADMIN_EMAIL, 'ADMIN_EMAIL'),
   adminPasswordHash: required(process.env.ADMIN_PASSWORD_HASH, 'ADMIN_PASSWORD_HASH'),
   googleServiceAccountJson: decodeBase64(

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,34 +1,54 @@
-import { Router, CookieOptions } from 'express';
+import express, { Router, CookieOptions } from 'express';
 import config from '../config/env';
-import { authService } from '../services/authService';
+import { authService } from '../services/container';
+import { AuthError } from '../services/authService';
 import { parseDurationToMilliseconds } from '../utils/duration';
 
 const REFRESH_TOKEN_COOKIE = 'refresh_token';
 
-const buildCookieOptions = (): CookieOptions => ({
-  httpOnly: true,
-  sameSite: (config.env === 'production' ? 'none' : 'lax') as CookieOptions['sameSite'],
-  secure: config.env === 'production',
-  maxAge: parseDurationToMilliseconds(config.jwtRefreshExpiresIn),
-  path: '/api/auth'
-});
+const buildCookieOptions = (): CookieOptions => {
+  const maxAge = parseDurationToMilliseconds(config.jwtRefreshExpiresIn) || 14 * 24 * 60 * 60 * 1000;
+  return {
+    httpOnly: true,
+    sameSite: (config.env === 'production' ? 'none' : 'lax') as CookieOptions['sameSite'],
+    secure: config.env === 'production',
+    maxAge,
+    path: '/api/auth'
+  };
+};
+
+const handleAuthError = (res: express.Response, error: unknown) => {
+  if (error instanceof AuthError) {
+    if (error.retryAfterSeconds !== undefined) {
+      res.setHeader('Retry-After', error.retryAfterSeconds.toString());
+    }
+    res.status(error.statusCode).json({ message: error.message });
+    return;
+  }
+  res.status(500).json({ message: 'Erro de autenticação' });
+};
 
 export const authController = Router();
 
 authController.post('/login', async (req, res) => {
-  const { email, password } = req.body;
+  const { email, password } = req.body ?? {};
+  const emailValue = typeof email === 'string' ? email : '';
+  const passwordValue = typeof password === 'string' ? password : '';
   try {
-    const result = await authService.login(email, password);
+    const result = await authService.login(emailValue, passwordValue, {
+      ip: req.ip,
+      userAgent: req.get('user-agent') || undefined
+    });
     const cookieOptions = buildCookieOptions();
     res
       .cookie(REFRESH_TOKEN_COOKIE, result.refreshToken, cookieOptions)
       .json({ accessToken: result.accessToken, expiresIn: result.expiresIn });
   } catch (error) {
-    res.status(401).json({ message: 'Credenciais inválidas' });
+    handleAuthError(res, error);
   }
 });
 
-authController.post('/refresh', (req, res) => {
+authController.post('/refresh', async (req, res) => {
   const cookieRefreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE];
   const bodyRefreshToken = typeof req.body?.refreshToken === 'string' ? req.body.refreshToken : undefined;
   const refreshToken = cookieRefreshToken || bodyRefreshToken;
@@ -39,18 +59,23 @@ authController.post('/refresh', (req, res) => {
   }
 
   try {
-    const result = authService.refresh(refreshToken);
+    const result = await authService.refresh(refreshToken, {
+      ip: req.ip,
+      userAgent: req.get('user-agent') || undefined
+    });
     const cookieOptions = buildCookieOptions();
     res
       .cookie(REFRESH_TOKEN_COOKIE, result.refreshToken, cookieOptions)
       .json({ accessToken: result.accessToken, expiresIn: result.expiresIn });
   } catch (error) {
-    res.status(401).json({ message: 'Token inválido' });
+    handleAuthError(res, error);
   }
 });
 
-authController.post('/logout', (_req, res) => {
+authController.post('/logout', async (req, res) => {
   const cookieOptions = buildCookieOptions();
+  const refreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE];
+  await authService.logout(refreshToken);
   res.clearCookie(REFRESH_TOKEN_COOKIE, { ...cookieOptions, maxAge: undefined });
   res.status(204).send();
 });

--- a/backend/src/middlewares/authMiddleware.ts
+++ b/backend/src/middlewares/authMiddleware.ts
@@ -1,17 +1,18 @@
 import { Request, Response, NextFunction } from 'express';
-import { authService } from '../services/authService';
+import { authService } from '../services/container';
 
 export interface AuthenticatedRequest extends Request {
   user?: {
     id: string;
     email: string;
+    role?: 'admin' | 'viewer';
   };
 }
 
 export const authMiddleware = (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
   const authHeader = req.headers.authorization;
   if (!authHeader) {
-    res.status(401).json({ message: 'N?o autenticado' });
+    res.status(401).json({ message: 'Não autenticado' });
     return;
   }
 
@@ -22,10 +23,10 @@ export const authMiddleware = (req: AuthenticatedRequest, res: Response, next: N
   }
 
   try {
-    const payload = authService.verifyToken(token, 'access');
-    req.user = { id: payload.sub || payload.email, email: payload.email };
+    const payload = authService.verifyAccessToken(token);
+    req.user = { id: payload.sub, email: payload.email, role: payload.role };
     next();
   } catch (error) {
-    res.status(401).json({ message: 'Token inv?lido' });
+    res.status(401).json({ message: 'Token inválido' });
   }
 };

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,13 +1,15 @@
+import { randomBytes } from 'crypto';
 import bcrypt from 'bcryptjs';
-import jwt, { SignOptions, Secret } from 'jsonwebtoken';
+import jwt, { JwtPayload, SignOptions, Secret } from 'jsonwebtoken';
+import { v4 as uuid } from 'uuid';
 import config from '../config/env';
-import { parseDurationToSeconds } from '../utils/duration';
-
-interface TokenPayload {
-  sub: string;
-  email: string;
-  type: 'access' | 'refresh';
-}
+import {
+  RefreshTokenRepository,
+  UserCredentialsRepository,
+  UserRepository
+} from '../repositories/interfaces';
+import { RefreshTokenRecord, User } from '../domain/types';
+import { parseDurationToMilliseconds, parseDurationToSeconds } from '../utils/duration';
 
 export interface LoginResult {
   accessToken: string;
@@ -15,19 +17,138 @@ export interface LoginResult {
   expiresIn: number;
 }
 
-class AuthService {
-  async login(email: string, password: string): Promise<LoginResult> {
-    if (email.toLowerCase() !== config.adminEmail.toLowerCase()) {
-      throw new Error('Credenciais inválidas');
+export interface AuthContext {
+  ip?: string;
+  userAgent?: string;
+}
+
+export interface AccessTokenPayload extends JwtPayload {
+  sub: string;
+  email: string;
+  role: 'admin' | 'viewer';
+  type: 'access';
+}
+
+const REFRESH_TOKEN_SEPARATOR = '.';
+const REFRESH_TOKEN_BYTES = 48;
+const REFRESH_TOKEN_BCRYPT_ROUNDS = 12;
+
+const LOGIN_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const LOGIN_RATE_LIMIT_MAX = 10;
+const LOGIN_LOCK_THRESHOLD = 5;
+const LOGIN_LOCK_DURATION_MS = 15 * 60 * 1000;
+
+type LoginAttemptState = {
+  attempts: number;
+  windowStart: number;
+  failures: number;
+  lockUntil?: number;
+};
+
+export class AuthError extends Error {
+  public readonly statusCode: number;
+  public readonly retryAfterSeconds?: number;
+
+  constructor(statusCode: number, message: string, retryAfterSeconds?: number) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.name = 'AuthError';
+    this.statusCode = statusCode;
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
+export class AuthService {
+  private readonly loginAttempts = new Map<string, LoginAttemptState>();
+
+  constructor(
+    private readonly users: UserRepository,
+    private readonly userCredentials: UserCredentialsRepository,
+    private readonly refreshTokens: RefreshTokenRepository
+  ) {}
+
+  async login(email: string, password: string, context: AuthContext = {}): Promise<LoginResult> {
+    const normalizedEmail = email?.trim().toLowerCase();
+    if (!normalizedEmail || !password) {
+      throw new AuthError(400, 'Email e senha são obrigatórios');
     }
 
-    const isValid = await bcrypt.compare(password, config.adminPasswordHash);
+    const { key, state } = this.checkRateLimit(normalizedEmail, context.ip);
+
+    const user = await this.users.getUserByEmail(normalizedEmail);
+    if (!user || user.status !== 'active') {
+      this.registerFailure(key, state);
+      throw new AuthError(401, 'Credenciais inválidas');
+    }
+
+    const isValid = await this.userCredentials.verifyUserPassword(user.id, password);
     if (!isValid) {
-      throw new Error('Credenciais inválidas');
+      this.registerFailure(key, state);
+      throw new AuthError(401, 'Credenciais inválidas');
     }
 
-    const accessToken = this.generateToken(email, 'access', config.jwtExpiresIn);
-    const refreshToken = this.generateToken(email, 'refresh', config.jwtRefreshExpiresIn);
+    this.resetFailures(key, state);
+
+    await this.updateLastLogin(user).catch(() => undefined);
+
+    return this.issueSession(user, context);
+  }
+
+  async refresh(refreshToken: string, context: AuthContext = {}): Promise<LoginResult> {
+    const parsed = this.parseRefreshToken(refreshToken);
+
+    const stored = await this.refreshTokens.findRefreshTokenById(parsed.id);
+    if (!stored || stored.revoked) {
+      throw new AuthError(401, 'Token de atualização inválido');
+    }
+
+    const expiresAt = Date.parse(stored.expiresAt);
+    if (Number.isFinite(expiresAt) && expiresAt <= Date.now()) {
+      await this.refreshTokens.revokeRefreshToken(stored.id).catch(() => undefined);
+      throw new AuthError(401, 'Token de atualização expirado');
+    }
+
+    const matches = await bcrypt.compare(parsed.secret, stored.tokenHash);
+    if (!matches) {
+      await this.refreshTokens.revokeRefreshToken(stored.id).catch(() => undefined);
+      throw new AuthError(401, 'Token de atualização inválido');
+    }
+
+    const user = await this.users.getUserById(stored.userId);
+    if (!user || user.status !== 'active') {
+      await this.refreshTokens.revokeRefreshToken(stored.id).catch(() => undefined);
+      throw new AuthError(401, 'Token de atualização inválido');
+    }
+
+    await this.refreshTokens.revokeRefreshToken(stored.id).catch(() => undefined);
+
+    return this.issueSession(user, context);
+  }
+
+  async logout(refreshToken?: string): Promise<void> {
+    if (!refreshToken) {
+      return;
+    }
+
+    try {
+      const parsed = this.parseRefreshToken(refreshToken);
+      await this.refreshTokens.revokeRefreshToken(parsed.id).catch(() => undefined);
+    } catch (error) {
+      // Silently ignore malformed tokens on logout
+    }
+  }
+
+  verifyAccessToken(token: string): AccessTokenPayload {
+    const decoded = jwt.verify(token, config.jwtSecret as Secret) as AccessTokenPayload;
+    if (!decoded || decoded.type !== 'access' || !decoded.sub || !decoded.email) {
+      throw new AuthError(401, 'Token de acesso inválido');
+    }
+    return decoded;
+  }
+
+  private async issueSession(user: User, context: AuthContext): Promise<LoginResult> {
+    const accessToken = this.generateAccessToken(user);
+    const refreshToken = await this.generateRefreshToken(user, context);
 
     return {
       accessToken,
@@ -36,38 +157,129 @@ class AuthService {
     };
   }
 
-  refresh(refreshToken: string): LoginResult {
-    const payload = this.verifyToken(refreshToken, 'refresh');
-
-    const accessToken = this.generateToken(payload.email, 'access', config.jwtExpiresIn);
-    const newRefreshToken = this.generateToken(payload.email, 'refresh', config.jwtRefreshExpiresIn);
-
-    return {
-      accessToken,
-      refreshToken: newRefreshToken,
-      expiresIn: parseDurationToSeconds(config.jwtExpiresIn)
-    };
-  }
-
-  verifyToken(token: string, type: 'access' | 'refresh' = 'access'): TokenPayload {
-    const decoded = jwt.verify(token, config.jwtSecret as Secret) as TokenPayload;
-    if (decoded.type !== type) {
-      throw new Error('Tipo de token inválido');
-    }
-    return decoded;
-  }
-
-  private generateToken(email: string, type: 'access' | 'refresh', expiresIn: string): string {
-    const payload: TokenPayload = {
-      sub: email,
-      email,
-      type
+  private generateAccessToken(user: User): string {
+    const payload: AccessTokenPayload = {
+      sub: user.id,
+      email: user.email,
+      role: user.role,
+      type: 'access'
     };
 
-    const options: SignOptions = { expiresIn: expiresIn as SignOptions['expiresIn'] };
+    const options: SignOptions = { expiresIn: config.jwtExpiresIn as SignOptions['expiresIn'] };
     return jwt.sign(payload, config.jwtSecret as Secret, options);
   }
 
-}
+  private async generateRefreshToken(user: User, context: AuthContext): Promise<string> {
+    const id = uuid();
+    const secret = randomBytes(REFRESH_TOKEN_BYTES).toString('hex');
+    const token = `${id}${REFRESH_TOKEN_SEPARATOR}${secret}`;
 
-export const authService = new AuthService();
+    const issuedAt = new Date();
+    const expiresInMs = parseDurationToMilliseconds(config.jwtRefreshExpiresIn) || 14 * 24 * 60 * 60 * 1000;
+    const expiresAt = new Date(issuedAt.getTime() + expiresInMs);
+
+    const record: RefreshTokenRecord = {
+      id,
+      userId: user.id,
+      tokenHash: await bcrypt.hash(secret, REFRESH_TOKEN_BCRYPT_ROUNDS),
+      issuedAt: issuedAt.toISOString(),
+      expiresAt: expiresAt.toISOString(),
+      userAgent: this.sanitizeMetadata(context.userAgent),
+      ip: this.sanitizeMetadata(context.ip),
+      revoked: false
+    };
+
+    await this.refreshTokens.saveRefreshToken(record);
+
+    return token;
+  }
+
+  private sanitizeMetadata(value?: string): string | undefined {
+    if (!value) {
+      return undefined;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    return trimmed.slice(0, 255);
+  }
+
+  private parseRefreshToken(token: string): { id: string; secret: string } {
+    const separatorIndex = token.indexOf(REFRESH_TOKEN_SEPARATOR);
+    if (separatorIndex <= 0 || separatorIndex === token.length - 1) {
+      throw new AuthError(400, 'Formato de refresh token inválido');
+    }
+    const id = token.slice(0, separatorIndex);
+    const secret = token.slice(separatorIndex + 1);
+    if (!id || !secret) {
+      throw new AuthError(400, 'Formato de refresh token inválido');
+    }
+    return { id, secret };
+  }
+
+  private async updateLastLogin(user: User): Promise<void> {
+    const now = new Date().toISOString();
+    await this.users.updateUser(user.id, { lastLoginAt: now, updatedAt: now });
+  }
+
+  private checkRateLimit(email: string, ip?: string): { key: string; state: LoginAttemptState } {
+    const key = this.buildAttemptKey(email, ip);
+    const now = Date.now();
+    const state = this.loginAttempts.get(key) ?? {
+      attempts: 0,
+      windowStart: now,
+      failures: 0
+    };
+
+    if (state.lockUntil && state.lockUntil <= now) {
+      state.lockUntil = undefined;
+      state.failures = 0;
+    }
+
+    if (state.lockUntil && state.lockUntil > now) {
+      const remainingSeconds = Math.max(1, Math.ceil((state.lockUntil - now) / 1000));
+      throw new AuthError(
+        423,
+        'Conta temporariamente bloqueada devido a múltiplas falhas. Tente novamente mais tarde.',
+        remainingSeconds
+      );
+    }
+
+    if (now - state.windowStart > LOGIN_RATE_LIMIT_WINDOW_MS) {
+      state.windowStart = now;
+      state.attempts = 0;
+    }
+
+    if (state.attempts >= LOGIN_RATE_LIMIT_MAX) {
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((state.windowStart + LOGIN_RATE_LIMIT_WINDOW_MS - now) / 1000)
+      );
+      throw new AuthError(429, 'Muitas tentativas de login. Aguarde antes de tentar novamente.', retryAfterSeconds);
+    }
+
+    state.attempts += 1;
+    this.loginAttempts.set(key, state);
+    return { key, state };
+  }
+
+  private registerFailure(key: string, state: LoginAttemptState): void {
+    state.failures += 1;
+    if (state.failures >= LOGIN_LOCK_THRESHOLD) {
+      state.lockUntil = Date.now() + LOGIN_LOCK_DURATION_MS;
+      state.failures = 0;
+    }
+    this.loginAttempts.set(key, state);
+  }
+
+  private resetFailures(key: string, state: LoginAttemptState): void {
+    state.failures = 0;
+    state.lockUntil = undefined;
+    this.loginAttempts.set(key, state);
+  }
+
+  private buildAttemptKey(email: string, ip?: string): string {
+    return `${email}|${ip ?? 'unknown'}`;
+  }
+}

--- a/backend/src/services/container.ts
+++ b/backend/src/services/container.ts
@@ -4,6 +4,7 @@ import { CertificateService } from './certificateService';
 import { AlertModelService } from './alertModelService';
 import { AuditService } from './auditService';
 import { ChannelService } from './channelService';
+import { AuthService } from './authService';
 
 const sheetsRepository = new GoogleSheetsRepository();
 
@@ -12,6 +13,7 @@ export const channelService = new ChannelService(sheetsRepository, auditService)
 export const certificateService = new CertificateService(sheetsRepository, auditService);
 export const alertModelService = new AlertModelService(sheetsRepository);
 export const notificationService = new NotificationService(auditService, channelService);
+export const authService = new AuthService(sheetsRepository, sheetsRepository, sheetsRepository);
 
 export const initializeServices = (): void => {
   // reserved for future initialisation (plugins, caches, etc.)


### PR DESCRIPTION
## Summary
- replace the auth service with a repository-backed implementation that stores hashed refresh tokens, enforces rate limiting/lockouts, and issues short-lived access tokens
- update the auth controller and middleware to use the new service, rotate refresh cookies, and surface authentication errors consistently
- wire the auth service into the service container and extend configuration defaults to support a 14-day refresh lifetime

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d97f2d99588330b618b78d7bae3c84