### PR TITLE
Implement secure authentication tokens

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -69,7 +69,7 @@ const config: AppConfig = {
   appBaseUrl: normalizeAppBaseUrl(required(process.env.APP_BASE_URL, 'APP_BASE_URL')),
   jwtSecret: required(process.env.JWT_SECRET, 'JWT_SECRET'),
   jwtExpiresIn: process.env.JWT_EXPIRES_IN || '15m',
-  jwtRefreshExpiresIn: process.env.JWT_REFRESH_EXPIRES_IN || '7d',
+  jwtRefreshExpiresIn: process.env.JWT_REFRESH_EXPIRES_IN || '14d',
   adminEmail: required(process.env.ADMIN_EMAIL, 'ADMIN_EMAIL'),
   adminPasswordHash: required(process.env.ADMIN_PASSWORD_HASH, 'ADMIN_PASSWORD_HASH'),
   googleServiceAccountJson: decodeBase64(

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,7 +1,14 @@
 import { Router, CookieOptions } from 'express';
 import config from '../config/env';
-import { authService } from '../services/authService';
+import { authRateLimiter } from '../middlewares/rateLimiter';
+import { authService } from '../services/container';
+import {
+  AccountLockedError,
+  InvalidCredentialsError,
+  InvalidTokenError
+} from '../services/authService';
 import { parseDurationToMilliseconds } from '../utils/duration';
+import logger from '../utils/logger';
 
 const REFRESH_TOKEN_COOKIE = 'refresh_token';
 
@@ -15,20 +22,35 @@ const buildCookieOptions = (): CookieOptions => ({
 
 export const authController = Router();
 
-authController.post('/login', async (req, res) => {
-  const { email, password } = req.body;
+authController.post('/login', authRateLimiter, async (req, res) => {
+  const { email, password } = req.body || {};
+  const context = {
+    userAgent: req.get('user-agent') || undefined,
+    ip: req.ip
+  };
+
   try {
-    const result = await authService.login(email, password);
+    const result = await authService.login(email, password, context);
     const cookieOptions = buildCookieOptions();
     res
       .cookie(REFRESH_TOKEN_COOKIE, result.refreshToken, cookieOptions)
       .json({ accessToken: result.accessToken, expiresIn: result.expiresIn });
   } catch (error) {
-    res.status(401).json({ message: 'Credenciais inválidas' });
+    if (error instanceof AccountLockedError) {
+      res.status(423).json({ message: error.message });
+      return;
+    }
+    if (error instanceof InvalidCredentialsError) {
+      res.status(401).json({ message: 'Credenciais inválidas' });
+      return;
+    }
+
+    logger.error({ error }, 'Falha inesperada ao realizar login');
+    res.status(500).json({ message: 'Erro ao efetuar login' });
   }
 });
 
-authController.post('/refresh', (req, res) => {
+authController.post('/refresh', async (req, res) => {
   const cookieRefreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE];
   const bodyRefreshToken = typeof req.body?.refreshToken === 'string' ? req.body.refreshToken : undefined;
   const refreshToken = cookieRefreshToken || bodyRefreshToken;
@@ -39,18 +61,40 @@ authController.post('/refresh', (req, res) => {
   }
 
   try {
-    const result = authService.refresh(refreshToken);
+    const context = {
+      userAgent: req.get('user-agent') || undefined,
+      ip: req.ip
+    };
+    const result = await authService.refresh(refreshToken, context);
     const cookieOptions = buildCookieOptions();
     res
       .cookie(REFRESH_TOKEN_COOKIE, result.refreshToken, cookieOptions)
       .json({ accessToken: result.accessToken, expiresIn: result.expiresIn });
   } catch (error) {
-    res.status(401).json({ message: 'Token inválido' });
+    if (error instanceof InvalidTokenError) {
+      res.status(401).json({ message: 'Token inválido' });
+      return;
+    }
+
+    logger.error({ error }, 'Falha inesperada ao renovar token');
+    res.status(500).json({ message: 'Erro ao renovar token' });
   }
 });
 
-authController.post('/logout', (_req, res) => {
+authController.post('/logout', async (req, res) => {
   const cookieOptions = buildCookieOptions();
+  const cookieRefreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE];
+  const bodyRefreshToken = typeof req.body?.refreshToken === 'string' ? req.body.refreshToken : undefined;
+  const refreshToken = cookieRefreshToken || bodyRefreshToken;
+
+  if (refreshToken) {
+    try {
+      await authService.logout(refreshToken);
+    } catch (error) {
+      logger.warn({ error }, 'Falha ao revogar refresh token durante logout');
+    }
+  }
+
   res.clearCookie(REFRESH_TOKEN_COOKIE, { ...cookieOptions, maxAge: undefined });
   res.status(204).send();
 });

--- a/backend/src/middlewares/authMiddleware.ts
+++ b/backend/src/middlewares/authMiddleware.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
-import { authService } from '../services/authService';
+import { authService } from '../services/container';
+import { InvalidTokenError } from '../services/authService';
 
 export interface AuthenticatedRequest extends Request {
   user?: {
@@ -11,7 +12,7 @@ export interface AuthenticatedRequest extends Request {
 export const authMiddleware = (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
   const authHeader = req.headers.authorization;
   if (!authHeader) {
-    res.status(401).json({ message: 'N?o autenticado' });
+    res.status(401).json({ message: 'Não autenticado' });
     return;
   }
 
@@ -26,6 +27,11 @@ export const authMiddleware = (req: AuthenticatedRequest, res: Response, next: N
     req.user = { id: payload.sub || payload.email, email: payload.email };
     next();
   } catch (error) {
-    res.status(401).json({ message: 'Token inv?lido' });
+    if (error instanceof InvalidTokenError) {
+      res.status(401).json({ message: 'Token inválido' });
+      return;
+    }
+
+    res.status(401).json({ message: 'Token inválido' });
   }
 };

--- a/backend/src/middlewares/rateLimiter.ts
+++ b/backend/src/middlewares/rateLimiter.ts
@@ -2,10 +2,19 @@ import rateLimit from 'express-rate-limit';
 import config from '../config/env';
 
 const sensitiveRoutePattern = /\/(test|send)(?:[/?]|$)/;
+const AUTH_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const AUTH_RATE_LIMIT_MAX = 5;
 
 export const apiRateLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 100,
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+export const authRateLimiter = rateLimit({
+  windowMs: AUTH_RATE_LIMIT_WINDOW_MS,
+  max: AUTH_RATE_LIMIT_MAX,
   standardHeaders: true,
   legacyHeaders: false
 });

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,12 +1,17 @@
-import bcrypt from 'bcryptjs';
-import jwt, { SignOptions, Secret } from 'jsonwebtoken';
+import crypto from 'crypto';
+import jwt, { JwtPayload, Secret, SignOptions } from 'jsonwebtoken';
+import { v4 as uuid } from 'uuid';
 import config from '../config/env';
 import { parseDurationToSeconds } from '../utils/duration';
+import logger from '../utils/logger';
+import { RefreshTokenRepository, UserCredentialsRepository, UserRepository } from '../repositories/interfaces';
+import { RefreshTokenRecord, User } from '../domain/types';
 
-interface TokenPayload {
+export interface TokenPayload extends JwtPayload {
   sub: string;
   email: string;
   type: 'access' | 'refresh';
+  jti?: string;
 }
 
 export interface LoginResult {
@@ -15,59 +20,240 @@ export interface LoginResult {
   expiresIn: number;
 }
 
-class AuthService {
-  async login(email: string, password: string): Promise<LoginResult> {
-    if (email.toLowerCase() !== config.adminEmail.toLowerCase()) {
-      throw new Error('Credenciais inválidas');
+export interface TokenContext {
+  userAgent?: string;
+  ip?: string;
+}
+
+export class InvalidCredentialsError extends Error {
+  constructor(message = 'Credenciais inválidas') {
+    super(message);
+    this.name = 'InvalidCredentialsError';
+  }
+}
+
+export class AccountLockedError extends Error {
+  constructor(message = 'Conta temporariamente bloqueada devido a múltiplas tentativas falhas.') {
+    super(message);
+    this.name = 'AccountLockedError';
+  }
+}
+
+export class InvalidTokenError extends Error {
+  constructor(message = 'Token inválido') {
+    super(message);
+    this.name = 'InvalidTokenError';
+  }
+}
+
+interface LoginAttemptState {
+  attempts: number;
+  lockedUntil?: number;
+}
+
+const MAX_LOGIN_ATTEMPTS = 5;
+const LOCK_DURATION_MS = 15 * 60 * 1000; // 15 minutes
+
+export class AuthService {
+  private readonly jwtSecret: Secret = config.jwtSecret as Secret;
+  private readonly loginAttempts = new Map<string, LoginAttemptState>();
+
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly userCredentialsRepository: UserCredentialsRepository,
+    private readonly refreshTokenRepository: RefreshTokenRepository
+  ) {}
+
+  async login(email: string, password: string, context: TokenContext = {}): Promise<LoginResult> {
+    const normalizedEmail = this.normalizeEmail(email);
+    if (!normalizedEmail || !password) {
+      this.recordFailedAttempt(normalizedEmail);
+      throw new InvalidCredentialsError();
     }
 
-    const isValid = await bcrypt.compare(password, config.adminPasswordHash);
-    if (!isValid) {
-      throw new Error('Credenciais inválidas');
+    this.ensureNotLocked(normalizedEmail);
+
+    const user = await this.userRepository.getUserByEmail(normalizedEmail);
+    if (!user || user.status !== 'active') {
+      this.recordFailedAttempt(normalizedEmail);
+      throw new InvalidCredentialsError();
     }
 
-    const accessToken = this.generateToken(email, 'access', config.jwtExpiresIn);
-    const refreshToken = this.generateToken(email, 'refresh', config.jwtRefreshExpiresIn);
+    const isValidPassword = await this.userCredentialsRepository.verifyUserPassword(user.id, password);
+    if (!isValidPassword) {
+      this.recordFailedAttempt(normalizedEmail);
+      throw new InvalidCredentialsError();
+    }
+
+    this.clearAttempts(normalizedEmail);
+    await this.updateLastLogin(user.id);
+
+    return this.issueTokens(user, context);
+  }
+
+  async refresh(refreshToken: string, context: TokenContext = {}): Promise<LoginResult> {
+    if (!refreshToken) {
+      throw new InvalidTokenError();
+    }
+
+    const payload = this.verifyToken(refreshToken, 'refresh');
+    const tokenHash = this.hashToken(refreshToken);
+    const stored = await this.refreshTokenRepository.findRefreshTokenByHash(tokenHash);
+
+    if (!stored || stored.revoked) {
+      throw new InvalidTokenError();
+    }
+
+    if (new Date(stored.expiresAt).getTime() <= Date.now()) {
+      await this.refreshTokenRepository.revokeRefreshToken(stored.id);
+      throw new InvalidTokenError('Token expirado');
+    }
+
+    if (stored.userId !== payload.sub) {
+      throw new InvalidTokenError();
+    }
+
+    const user = await this.userRepository.getUserById(stored.userId);
+    if (!user || user.status !== 'active') {
+      throw new InvalidTokenError();
+    }
+
+    await this.refreshTokenRepository.revokeRefreshToken(stored.id);
+
+    return this.issueTokens(user, context);
+  }
+
+  async logout(refreshToken?: string): Promise<void> {
+    if (!refreshToken) {
+      return;
+    }
+
+    const tokenHash = this.hashToken(refreshToken);
+    const stored = await this.refreshTokenRepository.findRefreshTokenByHash(tokenHash);
+    if (!stored) {
+      return;
+    }
+
+    await this.refreshTokenRepository.revokeRefreshToken(stored.id);
+  }
+
+  verifyToken(token: string, type: 'access' | 'refresh' = 'access'): TokenPayload {
+    try {
+      const decoded = jwt.verify(token, this.jwtSecret) as TokenPayload;
+      if (decoded.type !== type || typeof decoded.sub !== 'string') {
+        throw new InvalidTokenError();
+      }
+      return decoded;
+    } catch (error) {
+      if (error instanceof InvalidTokenError) {
+        throw error;
+      }
+      throw new InvalidTokenError();
+    }
+  }
+
+  private normalizeEmail(email?: string): string {
+    return (email || '').trim().toLowerCase();
+  }
+
+  private recordFailedAttempt(email: string): void {
+    if (!email) {
+      return;
+    }
+    const current = this.loginAttempts.get(email) || { attempts: 0 };
+    const attempts = current.attempts + 1;
+    const nextState: LoginAttemptState = { attempts };
+
+    if (attempts >= MAX_LOGIN_ATTEMPTS) {
+      nextState.lockedUntil = Date.now() + LOCK_DURATION_MS;
+    }
+
+    this.loginAttempts.set(email, nextState);
+  }
+
+  private ensureNotLocked(email: string): void {
+    const state = this.loginAttempts.get(email);
+    if (!state || !state.lockedUntil) {
+      return;
+    }
+
+    if (state.lockedUntil > Date.now()) {
+      throw new AccountLockedError();
+    }
+
+    this.loginAttempts.delete(email);
+  }
+
+  private clearAttempts(email: string): void {
+    this.loginAttempts.delete(email);
+  }
+
+  private async updateLastLogin(userId: string): Promise<void> {
+    try {
+      await this.userRepository.updateUser(userId, { lastLoginAt: new Date().toISOString() });
+    } catch (error) {
+      logger.warn({ userId, error }, 'Failed to update last login');
+    }
+  }
+
+  private async issueTokens(user: User, context: TokenContext): Promise<LoginResult> {
+    const accessToken = this.generateAccessToken(user);
+    const tokenId = uuid();
+    const refreshToken = this.generateRefreshToken(user, tokenId);
+
+    const now = new Date();
+    const accessExpiresIn = parseDurationToSeconds(config.jwtExpiresIn) || 0;
+    const refreshExpiresInSeconds = parseDurationToSeconds(config.jwtRefreshExpiresIn) || 0;
+    const refreshExpiresAt = new Date(now.getTime() + refreshExpiresInSeconds * 1000);
+
+    const record: RefreshTokenRecord = {
+      id: tokenId,
+      userId: user.id,
+      tokenHash: this.hashToken(refreshToken),
+      issuedAt: now.toISOString(),
+      expiresAt: refreshExpiresAt.toISOString(),
+      userAgent: context.userAgent,
+      ip: context.ip,
+      revoked: false
+    };
+
+    await this.refreshTokenRepository.saveRefreshToken(record);
 
     return {
       accessToken,
       refreshToken,
-      expiresIn: parseDurationToSeconds(config.jwtExpiresIn)
+      expiresIn: accessExpiresIn
     };
   }
 
-  refresh(refreshToken: string): LoginResult {
-    const payload = this.verifyToken(refreshToken, 'refresh');
-
-    const accessToken = this.generateToken(payload.email, 'access', config.jwtExpiresIn);
-    const newRefreshToken = this.generateToken(payload.email, 'refresh', config.jwtRefreshExpiresIn);
-
-    return {
-      accessToken,
-      refreshToken: newRefreshToken,
-      expiresIn: parseDurationToSeconds(config.jwtExpiresIn)
-    };
+  private generateAccessToken(user: User): string {
+    const options: SignOptions = { expiresIn: config.jwtExpiresIn as SignOptions['expiresIn'] };
+    return jwt.sign(
+      {
+        sub: user.id,
+        email: user.email,
+        type: 'access'
+      },
+      this.jwtSecret,
+      options
+    );
   }
 
-  verifyToken(token: string, type: 'access' | 'refresh' = 'access'): TokenPayload {
-    const decoded = jwt.verify(token, config.jwtSecret as Secret) as TokenPayload;
-    if (decoded.type !== type) {
-      throw new Error('Tipo de token inválido');
-    }
-    return decoded;
+  private generateRefreshToken(user: User, tokenId: string): string {
+    const options: SignOptions = { expiresIn: config.jwtRefreshExpiresIn as SignOptions['expiresIn'] };
+    return jwt.sign(
+      {
+        sub: user.id,
+        email: user.email,
+        type: 'refresh',
+        jti: tokenId
+      },
+      this.jwtSecret,
+      options
+    );
   }
 
-  private generateToken(email: string, type: 'access' | 'refresh', expiresIn: string): string {
-    const payload: TokenPayload = {
-      sub: email,
-      email,
-      type
-    };
-
-    const options: SignOptions = { expiresIn: expiresIn as SignOptions['expiresIn'] };
-    return jwt.sign(payload, config.jwtSecret as Secret, options);
+  private hashToken(token: string): string {
+    return crypto.createHash('sha256').update(token).digest('hex');
   }
-
 }
-
-export const authService = new AuthService();

--- a/backend/src/services/container.ts
+++ b/backend/src/services/container.ts
@@ -4,9 +4,11 @@ import { CertificateService } from './certificateService';
 import { AlertModelService } from './alertModelService';
 import { AuditService } from './auditService';
 import { ChannelService } from './channelService';
+import { AuthService } from './authService';
 
 const sheetsRepository = new GoogleSheetsRepository();
 
+export const authService = new AuthService(sheetsRepository, sheetsRepository, sheetsRepository);
 export const auditService = new AuditService(sheetsRepository);
 export const channelService = new ChannelService(sheetsRepository, auditService);
 export const certificateService = new CertificateService(sheetsRepository, auditService);


### PR DESCRIPTION
## Summary
- replace the authentication service with a user-aware implementation that stores hashed refresh tokens, rotates them, and locks accounts after repeated failures
- update the auth controller, middleware, and service container to use the new service, add contextual logging, and set httpOnly cookies while supporting logout token revocation
- add login rate limiting and extend configuration defaults to give refresh tokens a 14 day lifetime

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d97f2d99588330b618b78d7bae3c84