### PR TITLE
Implement RBAC middleware for certificate and alert routes

### DIFF
--- a/backend/src/controllers/alertModelController.ts
+++ b/backend/src/controllers/alertModelController.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { alertModelService } from '../services/container';
+import { requireRoles } from '../middlewares/rbacMiddleware';
 
 export const alertModelController = Router();
 
@@ -8,7 +9,7 @@ alertModelController.get('/', async (_req, res) => {
   res.json(models);
 });
 
-alertModelController.post('/', async (req, res) => {
+alertModelController.post('/', requireRoles('admin', 'editor'), async (req, res) => {
   try {
     const created = await alertModelService.create(req.body);
     res.status(201).json(created);
@@ -17,7 +18,7 @@ alertModelController.post('/', async (req, res) => {
   }
 });
 
-alertModelController.put('/:id', async (req, res) => {
+alertModelController.put('/:id', requireRoles('admin', 'editor'), async (req, res) => {
   try {
     const updated = await alertModelService.update(req.params.id, req.body);
     res.json(updated);
@@ -26,7 +27,7 @@ alertModelController.put('/:id', async (req, res) => {
   }
 });
 
-alertModelController.delete('/:id', async (req, res) => {
+alertModelController.delete('/:id', requireRoles('admin', 'editor'), async (req, res) => {
   await alertModelService.delete(req.params.id);
   res.status(204).send();
 });

--- a/backend/src/controllers/certificateController.ts
+++ b/backend/src/controllers/certificateController.ts
@@ -5,6 +5,7 @@ import type { CertificateInput } from '../services/certificateService';
 import { parseDate, now } from '../utils/time';
 import { sanitizeString } from '../utils/validators';
 import { channelTestRateLimiter } from '../middlewares/rateLimiter';
+import { requireRoles } from '../middlewares/rbacMiddleware';
 
 const extractChannelIds = (source: Record<string, unknown>): string[] => {
   if (Array.isArray(source.channelIds)) {
@@ -124,7 +125,7 @@ certificateController.get('/', async (req, res) => {
   res.json(filtered);
 });
 
-certificateController.post('/', async (req: AuthenticatedRequest, res) => {
+certificateController.post('/', requireRoles('admin', 'editor'), async (req: AuthenticatedRequest, res) => {
   try {
     const actor = req.user ?? { id: 'system', email: 'system@local' };
     const payload = parseCertificateCreatePayload(req.body);
@@ -135,7 +136,7 @@ certificateController.post('/', async (req: AuthenticatedRequest, res) => {
   }
 });
 
-certificateController.put('/:id', async (req: AuthenticatedRequest, res) => {
+certificateController.put('/:id', requireRoles('admin', 'editor'), async (req: AuthenticatedRequest, res) => {
   try {
     const actor = req.user ?? { id: 'system', email: 'system@local' };
     const payload = parseCertificateUpdatePayload(req.body);
@@ -146,7 +147,7 @@ certificateController.put('/:id', async (req: AuthenticatedRequest, res) => {
   }
 });
 
-certificateController.delete('/:id', async (req: AuthenticatedRequest, res) => {
+certificateController.delete('/:id', requireRoles('admin', 'editor'), async (req: AuthenticatedRequest, res) => {
   const actor = req.user ?? { id: 'system', email: 'system@local' };
   await certificateService.delete(req.params.id, actor);
   res.status(204).send();
@@ -157,7 +158,7 @@ certificateController.get('/:id/channels', async (req, res) => {
   res.json(links);
 });
 
-certificateController.post('/:id/channels', async (req: AuthenticatedRequest, res) => {
+certificateController.post('/:id/channels', requireRoles('admin', 'editor'), async (req: AuthenticatedRequest, res) => {
   const actor = req.user ?? { id: 'system', email: 'system@local' };
   const source = (req.body ?? {}) as Record<string, unknown>;
   const channelIds = extractChannelIds(source);
@@ -165,33 +166,37 @@ certificateController.post('/:id/channels', async (req: AuthenticatedRequest, re
   res.json({ channelIds });
 });
 
-certificateController.post('/:id/test-notification', channelTestRateLimiter, async (req, res) => {
-  const certificate = await certificateService.get(req.params.id);
-  if (!certificate) {
-    res.status(404).json({ message: 'Certificado não encontrado' });
-    return;
-  }
+certificateController.post(
+  '/:id/test-notification',
+  requireRoles('admin', 'editor'),
+  channelTestRateLimiter,
+  async (req, res) => {
+    const certificate = await certificateService.get(req.params.id);
+    if (!certificate) {
+      res.status(404).json({ message: 'Certificado não encontrado' });
+      return;
+    }
 
-  if (!certificate.alertModelId) {
-    res.status(400).json({ message: 'Certificado sem modelo de alerta vinculado' });
-    return;
-  }
+    if (!certificate.alertModelId) {
+      res.status(400).json({ message: 'Certificado sem modelo de alerta vinculado' });
+      return;
+    }
 
-  const alertModel = await alertModelService.get(certificate.alertModelId);
-  if (!alertModel) {
-    res.status(400).json({ message: 'Modelo de alerta não encontrado' });
-    return;
-  }
+    const alertModel = await alertModelService.get(certificate.alertModelId);
+    if (!alertModel) {
+      res.status(400).json({ message: 'Modelo de alerta não encontrado' });
+      return;
+    }
 
-  const daysLeft = Math.floor(parseDate(certificate.expiresAt).diff(now(), 'days').days);
+    const daysLeft = Math.floor(parseDate(certificate.expiresAt).diff(now(), 'days').days);
 
-  const actor = (req as AuthenticatedRequest).user ?? { id: 'system', email: 'system@local' };
+    const actor = (req as AuthenticatedRequest).user ?? { id: 'system', email: 'system@local' };
 
-  try {
-    await notificationService.sendAlerts(certificate, alertModel, daysLeft, actor);
-    res.json({ message: 'Notificação de teste enviada' });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Falha ao enviar notificações';
-    res.status(500).json({ message });
-  }
-});
+    try {
+      await notificationService.sendAlerts(certificate, alertModel, daysLeft, actor);
+      res.json({ message: 'Notificação de teste enviada' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Falha ao enviar notificações';
+      res.status(500).json({ message });
+    }
+);

--- a/backend/src/domain/types.ts
+++ b/backend/src/domain/types.ts
@@ -82,11 +82,13 @@ export interface AuditLog {
 
 export type UserStatus = 'active' | 'inactive';
 
+export type UserRole = 'admin' | 'editor' | 'viewer';
+
 export interface User {
   id: string;
   email: string;
   name: string;
-  role: 'admin' | 'viewer';
+  role: UserRole;
   status: UserStatus;
   createdAt: string;
   updatedAt: string;

--- a/backend/src/middlewares/authMiddleware.ts
+++ b/backend/src/middlewares/authMiddleware.ts
@@ -5,7 +5,7 @@ export interface AuthenticatedRequest extends Request {
   user?: {
     id: string;
     email: string;
-    role?: 'admin' | 'viewer';
+    role?: 'admin' | 'editor' | 'viewer';
   };
 }
 

--- a/backend/src/middlewares/rbacMiddleware.ts
+++ b/backend/src/middlewares/rbacMiddleware.ts
@@ -1,0 +1,23 @@
+import { NextFunction, Response } from 'express';
+import { UserRole } from '../domain/types';
+import { AuthenticatedRequest } from './authMiddleware';
+
+export const requireRoles = (...roles: UserRole[]) => {
+  const allowed = new Set<UserRole>(roles);
+
+  return (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
+    const role = req.user?.role;
+
+    if (!role) {
+      res.status(403).json({ message: 'Acesso negado' });
+      return;
+    }
+
+    if (role === 'admin' || allowed.has(role)) {
+      next();
+      return;
+    }
+
+    res.status(403).json({ message: 'Acesso negado' });
+  };
+};

--- a/backend/src/repositories/googleSheetsRepository.ts
+++ b/backend/src/repositories/googleSheetsRepository.ts
@@ -14,7 +14,8 @@ import {
   ChannelType,
   RefreshTokenRecord,
   User,
-  UserCredentials
+  UserCredentials,
+  UserRole
 } from '../domain/types';
 import {
   AlertModelRepository,
@@ -243,7 +244,7 @@ export class GoogleSheetsRepository
       id: map['id'],
       email: map['email'],
       name: map['name'],
-      role: (map['role'] as User['role']) || 'admin',
+      role: (map['role'] as UserRole) || 'admin',
       status: (map['status'] as User['status']) || 'active',
       createdAt: map['created_at'] || '',
       updatedAt: map['updated_at'] || map['created_at'] || '',

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -8,7 +8,7 @@ import {
   UserCredentialsRepository,
   UserRepository
 } from '../repositories/interfaces';
-import { RefreshTokenRecord, User } from '../domain/types';
+import { RefreshTokenRecord, User, UserRole } from '../domain/types';
 import { parseDurationToMilliseconds, parseDurationToSeconds } from '../utils/duration';
 
 export interface LoginResult {
@@ -25,7 +25,7 @@ export interface AuthContext {
 export interface AccessTokenPayload extends JwtPayload {
   sub: string;
   email: string;
-  role: 'admin' | 'viewer';
+  role: UserRole;
   type: 'access';
 }
 


### PR DESCRIPTION
## Summary
- introduce a reusable RBAC middleware that authorizes requests based on JWT roles
- protect certificate and alert model mutation routes so that only admin/editor roles can modify data
- expand role types to include the new editor role across domain models, auth payloads, and repositories

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9890762a48330b94574bbe36ba9ba