### PR TITLE
Add channel deletion workflow and unlinking safeguards

### DIFF
--- a/backend/src/controllers/channelController.ts
+++ b/backend/src/controllers/channelController.ts
@@ -92,6 +92,10 @@ channelController.post(
 
 channelController.delete('/:id', async (req: AuthenticatedRequest, res) => {
   const actor = resolveRequestActor(req);
-  await channelService.softDelete(req.params.id, actor);
-  res.status(204).send();
+  try {
+    await channelService.softDelete(req.params.id, actor);
+    res.status(204).send();
+  } catch (error) {
+    res.status(400).json({ message: String(error) });
+  }
 });

--- a/backend/src/domain/types.ts
+++ b/backend/src/domain/types.ts
@@ -21,6 +21,8 @@ export type AuditAction =
   | 'link'
   | 'unlink'
   | 'notification_sent'
+  | 'channel_delete'
+  | 'channel_unlink'
   | 'user_create'
   | 'user_update'
   | 'user_disable'
@@ -54,6 +56,7 @@ export interface ChannelInstance {
   name: string;
   type: ChannelType;
   enabled: boolean;
+  deleted: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/backend/src/repositories/interfaces.ts
+++ b/backend/src/repositories/interfaces.ts
@@ -35,6 +35,7 @@ export interface ChannelRepository {
   createChannel(channel: ChannelInstance, params: ChannelParam[], secrets: ChannelSecret[]): Promise<void>;
   updateChannel(channel: ChannelInstance, params: ChannelParam[], secrets: ChannelSecret[]): Promise<void>;
   softDeleteChannel(id: string, timestamp: string): Promise<void>;
+  unlinkChannel(channelId: string): Promise<CertificateChannelLink[]>;
   getChannelParams(id: string): Promise<ChannelParam[]>;
   getChannelSecrets(id: string): Promise<ChannelSecret[]>;
 }

--- a/backend/src/services/container.ts
+++ b/backend/src/services/container.ts
@@ -11,7 +11,11 @@ const sheetsRepository = new GoogleSheetsRepository();
 
 export const auditService = new AuditService(sheetsRepository);
 export const channelService = new ChannelService(sheetsRepository, auditService);
-export const certificateService = new CertificateService(sheetsRepository, auditService);
+export const certificateService = new CertificateService(
+  sheetsRepository,
+  auditService,
+  sheetsRepository
+);
 export const alertModelService = new AlertModelService(sheetsRepository, auditService);
 export const notificationService = new NotificationService(auditService, channelService);
 export const authService = new AuthService(

--- a/frontend/src/services/channels.ts
+++ b/frontend/src/services/channels.ts
@@ -24,7 +24,7 @@ export const updateChannel = async (id: string, payload: ChannelPayload): Promis
   return data;
 };
 
-export const disableChannel = async (id: string): Promise<void> => {
+export const deleteChannel = async (id: string): Promise<void> => {
   await api.delete(`/channels/${id}`);
 };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -43,6 +43,7 @@ export interface ChannelInstance {
   name: string;
   type: ChannelType;
   enabled: boolean;
+  deleted: boolean;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- add channel soft delete handling with automatic certificate unlinks and audit logging
- store channel deletion state in sheets and validate requested channel links in the certificate service
- update channel and certificate screens to expose delete actions and hide removed connectors

## Testing
- npm run build (backend)
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d9b84d8f288330aab751ce0f6fb163