### PR TITLE
Atualizar documentação de implantação e variáveis de ambiente

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,137 +1,112 @@
-# Cert Manager – Base de Integração
+# Cert Manager – Guia de Implantação
 
-Este repositório entrega o alicerce do gerenciador de certificados com API Express, persistência em Google Sheets e frontend Vite. A base já incorpora preocupações de segurança e observabilidade:
+## 1. Visão geral
+O Cert Manager centraliza o ciclo de vida de certificados e alertas:
+- **Gestão de certificados** com controle de validade, responsáveis e canais vinculados.
+- **Modelos de alerta** para definir assunto, conteúdo e frequência dos avisos.
+- **Canais de notificação** com parâmetros e segredos criptografados.
+- **Auditoria append-only** para todas as ações relevantes.
+- **Gestão de usuários** com autenticação baseada em cookies HTTP-only.
 
-- CORS restrito à `APP_BASE_URL` definida em ambiente.
-- Autenticação JWT em cookie `httpOnly` com refresh automático e expiração configurável.
-- Rate limiting dedicado para endpoints sensíveis (`/test` e `/send`).
-- Logs estruturados em JSON (Pino) e métricas Prometheus opcionais.
+Arquitetura resumida:
+- **Frontend** em React/Vite distribuído por Nginx.
+- **Backend/Worker** em Node.js (Express + scheduler) com filas cronometradas.
+- **Google Sheets** funciona como a "base de dados" do sistema.
+- **Containers Docker** orquestram frontend, backend e scheduler via Docker Compose.
 
-## Estrutura do projeto
-```
-backend/   API Express + serviços + repositórios (TypeScript)
-frontend/  Aplicação Vite (React + Tailwind) pronta para a UI
-scripts/   Utilitários (ex.: seed do Google Sheets)
-```
+## 2. Pré-requisitos
+- Docker e Docker Compose instalados.
+- Ferramentas `openssl` e `base64` disponíveis (Linux/macOS já possuem por padrão).
+- Conta Google com acesso ao Google Cloud Console para criar projeto, ativar APIs e gerar Service Account.
 
-## Google Sheets – criação das abas e cabeçalhos
-1. Crie uma planilha vazia no Google Sheets e anote o ID (parte após `/spreadsheets/d/`).
-2. Execute o seed (`npm run seed:sheets` dentro de `backend/`) após configurar as variáveis de ambiente – ele cria/atualiza todas as abas necessárias.
-3. Caso precise montar manualmente, utilize a tabela abaixo:
+## 3. Variáveis PRINCIPAIS (obrigatórias)
+Crie `backend/.env` a partir de `backend/.env.example` e preencha todas as variáveis abaixo.
 
-| Aba | Cabeçalhos |
+| NOME | O QUE É | COMO OBTER/GERAR | COMANDO |
+| --- | --- | --- | --- |
+| `APP_BASE_URL` | Origem autorizada para o frontend consumir o backend e receber cookies. | Defina para a URL pública do frontend ou do ambiente local. | `read -p 'Informe a URL pública do frontend: ' APP_BASE_URL && printf '%s\n' "$APP_BASE_URL"` |
+| `JWT_SECRET` | Segredo usado para assinar os tokens de sessão. | Gere um valor aleatório de alta entropia. | `openssl rand -base64 48` |
+| `ADMIN_EMAIL` | E-mail do usuário administrador inicial, usado no seed. | Utilize um endereço controlado pela equipe responsável. | `read -p 'Informe o e-mail administrativo primário: ' ADMIN_EMAIL && printf '%s\n' "$ADMIN_EMAIL"` |
+| `ADMIN_PASSWORD_HASH` | Hash BCrypt (custo 12) da senha do administrador inicial. | Gere uma senha forte e converta para hash. | `read -s -p 'Defina a senha do admin: ' ADMIN_PASSWORD && printf '\n' && env ADMIN_PASSWORD="$ADMIN_PASSWORD" node -e "const bcrypt=require('bcryptjs');console.log(bcrypt.hashSync(process.env.ADMIN_PASSWORD, 12));"` |
+| `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64` | Credenciais da Service Account codificadas em Base64 (string única). | Após gerar a chave JSON, converta o arquivo para Base64 sem quebras de linha. | `openssl base64 -A -in CAMINHO/DA/SERVICE-ACCOUNT.json` |
+| `SHEETS_SPREADSHEET_ID` | Identificador da planilha do Google Sheets usada como banco. | Copie o trecho entre `/spreadsheets/d/` e `/edit` da URL da planilha. | `read -p 'Cole o ID da planilha do Google Sheets: ' SHEETS_SPREADSHEET_ID && printf '%s\n' "$SHEETS_SPREADSHEET_ID"` |
+| `ENCRYPTION_KEY` | Chave AES-256 em Base64 usada para cifrar segredos de canais. | Gere 32 bytes aleatórios e codifique em Base64. | `openssl rand -base64 32` |
+
+> Execute o comando de hash dentro do diretório `backend` após instalar as dependências (`npm install`). Após gerar todos os valores, preencha-os manualmente no `backend/.env` e mantenha os segredos em local seguro.
+
+## 4. Variáveis OPCIONAIS (defaults definidos no código)
+Caso deseje alterar qualquer valor abaixo, adicione a variável correspondente manualmente no seu `.env`. Sem sobrescrita, o backend utilizará os padrões a seguir.
+
+| NOME | DEFAULT | DESCRIÇÃO |
+| --- | --- | --- |
+| `PORT` | `8080` | Porta HTTP exposta pelo backend.
+| `NODE_ENV` | `development` | Ambiente lógico usado para logs e diagnósticos.
+| `JWT_EXPIRES_IN` | `15m` | Validade do token de acesso.
+| `JWT_REFRESH_EXPIRES_IN` | `14d` | Validade do token de refresh.
+| `JWT_COOKIE_SAMESITE` | `lax` | Política SameSite aplicada ao cookie de sessão.
+| `CACHE_TTL_SECONDS` | `60` | Tempo de vida do cache em memória para leituras do Sheets.
+| `TZ` | `America/Fortaleza` | Fuso horário base para logs e agendamentos.
+| `SCHEDULER_ENABLED` | `false` | Ativa (`true`) ou desativa (`false`) o worker de agendamentos.
+| `SCHEDULER_INTERVAL_MINUTES` | `1` | Intervalo mínimo entre execuções do scheduler (valores menores que 1 são corrigidos para 1).
+| `METRICS_ENABLED` | `true` | Controla a exposição do endpoint `/api/metrics`.
+| `LOG_LEVEL` | `info` | Nível de log estruturado.
+| `RATE_LIMIT_GLOBAL_WINDOW_MS` | `60000` | Janela global (ms) do limitador de requisições.
+| `RATE_LIMIT_GLOBAL_MAX` | `300` | Total de requisições permitidas por IP na janela global.
+| `RATE_LIMIT_TEST_WINDOW_MS` | `60000` | Janela (ms) para testes de canais.
+| `RATE_LIMIT_TEST_MAX` | `5` | Limite de testes de canais na janela configurada.
+| `RATE_LIMIT_SENSITIVE_WINDOW_MS` | `60000` | Janela (ms) para rotas sensíveis.
+| `RATE_LIMIT_SENSITIVE_MAX` | `10` | Limite de requisições em rotas sensíveis.
+
+## 5. Passo a passo – preparando o "banco" (Google Sheets + Service Account)
+1. **Criar projeto**: no [Google Cloud Console](https://console.cloud.google.com/), crie um projeto dedicado ao Cert Manager.
+2. **Ativar API**: habilite a *Google Sheets API* para o projeto.
+3. **Service Account**:
+   - Crie uma Service Account com permissão mínima de *Editor* na API do Sheets.
+   - Gere uma chave JSON e armazene o arquivo com segurança.
+   - Converta o JSON em Base64 com `openssl base64 -A -in CAMINHO/DA/SERVICE-ACCOUNT.json` e preencha `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64`.
+4. **Planilha**:
+   - Crie uma planilha vazia no Google Sheets e anote o ID.
+   - Compartilhe a planilha com o e-mail da Service Account concedendo o papel **Editor**.
+5. **Configurar ambiente local**:
+   - `cd backend`.
+   - `cp .env.example .env` e preencha as variáveis principais.
+6. **Seed/Migrate**:
+   - Garanta que os pacotes estejam instalados: `npm install`.
+   - Execute `ADMIN_INITIAL_PASSWORD="$(openssl rand -base64 24)" npm run seed:sheets`. Esse comando cria/atualiza as abas, cabeçalhos e garante o usuário administrador usando a senha fornecida.
+   - Caso esteja atualizando uma planilha existente criada em versões anteriores, rode também `npm run migrate:sheets:alert-schedule`.
+7. **Registrar a senha inicial**: guarde a senha gerada para entregar ao administrador. Solicite que altere no primeiro acesso.
+
+## 6. Como rodar
+1. Do diretório raiz, construa e inicie os serviços: `docker compose up -d`.
+2. Acompanhe os health checks:
+   - `docker compose ps` para verificar o status geral.
+   - `docker compose logs backend -f` para logs da API.
+   - `docker compose logs scheduler -f` para o worker de agendamentos.
+   - `docker compose exec backend curl -f http://localhost:8080/api/health` para validar o endpoint de saúde.
+3. O frontend fica disponível na porta exposta pelo container (por padrão 3000 via Nginx).
+
+## 7. Como rotacionar chaves
+1. Gere novas credenciais com `openssl rand -base64 48` para `JWT_SECRET` e `openssl rand -base64 32` para `ENCRYPTION_KEY`.
+2. Atualize os valores seguros no cofre/gerenciador de segredos da sua infraestrutura.
+3. Edite o `.env` (e quaisquer variáveis gerenciadas por pipelines) com os novos valores.
+4. Reinicie os containers afetados: `docker compose up -d backend scheduler`.
+5. Para a Service Account, gere uma nova chave, atualize `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64`, rode `docker compose up -d backend scheduler` e revogue a chave antiga no Google Cloud.
+
+## 8. Observações de segurança
+- Utilize cookies `httpOnly` e `Secure` em produção (o backend já configura automaticamente ao detectar HTTPS).
+- Ative mecanismos de rate limit adicionais em front-ends públicos ou WAFs se necessário.
+- A auditoria salva todos os eventos como registros append-only; nunca edite diretamente a aba `audit_logs`.
+- Segredos (JWT, chave de criptografia, JSON da Service Account) não devem ser versionados nem compartilhados fora de canais seguros.
+
+## 9. FAQ / Troubleshooting
+| Problema | Como resolver |
 | --- | --- |
-| `certificates` | `id`, `name`, `owner_email`, `issued_at`, `expires_at`, `status`, `alert_model_id`, `notes`, `channel_ids` |
-| `alert_models` | `id`, `name`, `offset_days_before`, `offset_days_after`, `repeat_every_days`, `template_subject`, `template_body`, `schedule_type`, `schedule_time`, `enabled` |
-| `channels` | `id`, `name`, `type`, `enabled`, `created_at`, `updated_at` |
-| `channel_params` | `channel_id`, `key`, `value`, `updated_at` |
-| `channel_secrets` | `channel_id`, `key`, `value_ciphertext`, `updated_at` |
-| `certificate_channels` | `certificate_id`, `channel_id`, `linked_at`, `linked_by_user_id` |
-| `audit_logs` | `timestamp`, `actor_user_id`, `actor_email`, `entity`, `entity_id`, `action`, `diff_json`, `ip`, `user_agent`, `note` |
+| Erro de permissão ao acessar o Google Sheets | Verifique se a Service Account foi compartilhada como **Editor** e se a Sheets API está habilitada. Revise também o ID da planilha no `.env`. |
+| Falha ao decodificar `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64` | Gere novamente o Base64 sem quebras de linha usando `openssl base64 -A -in CAMINHO/DA/SERVICE-ACCOUNT.json`. |
+| Mensagem de Base64 inválido em `ENCRYPTION_KEY` | Confirme se a saída de `openssl rand -base64 32` foi copiada sem espaços extras. |
+| Abas ausentes após o seed | Execute novamente `ADMIN_INITIAL_PASSWORD="$(openssl rand -base64 24)" npm run seed:sheets` e confirme no log se todas as abas foram criadas. |
+| Login do admin falhando | Refaça o seed garantindo que `ADMIN_EMAIL` e `ADMIN_PASSWORD_HASH` coincidam com os valores presentes no `.env` e que `ADMIN_INITIAL_PASSWORD` foi informado ao rodar o seed. |
+| Base64 da Service Account com caracteres quebrados no `.env` | Cole o valor em uma linha única e utilize aspas apenas se o seu gerenciador exigir. |
+| Scheduler sem enviar alertas | Confirme se `SCHEDULER_ENABLED` está configurado como `true` no `.env` e reinicie o container `scheduler`. |
 
-> As abas `certificates` e `alert_models` continuam compatíveis com dados antigos (apenas adicionamos `channel_ids`).
-
-### Atualização de planilhas existentes
-
-Caso já utilize a planilha com dados anteriores, execute o script de migração para adicionar os novos campos de agendamento em `alert_models`:
-
-1. `cd backend`
-2. `npm run migrate:sheets:alert-schedule`
-
-O script garante a criação das colunas `schedule_type`, `schedule_time` e `enabled` (com valores padrões `hourly`, vazio e `true`) sem alterar as demais informações.
-
-## Service Account e permissões
-1. No Google Cloud, crie um projeto e habilite a Sheets API.
-2. Crie uma Service Account, gere a chave JSON e salve o arquivo com segurança.
-3. Compartilhe a planilha com o e-mail da Service Account (permissão **Editor**).
-4. Converta o JSON para Base64 (`cat service-account.json | openssl base64 -A`) e preencha `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64`.
-5. Caso troque a chave, atualize o `.env`, substitua os segredos criptografados (ver seção abaixo) e remova a chave antiga.
-
-## Variáveis de ambiente, criptografia e segredos
-### Arquivos `.env`
-- `backend/.env.example` lista todas as variáveis exigidas pelo backend. Copie para `backend/.env` e preencha valores reais.
-- `frontend/.env.example` expõe `VITE_API_URL`; copie para `frontend/.env` para apontar o frontend ao backend desejado.
-
-### Principais variáveis
-| Variável | Descrição |
-| --- | --- |
-| `APP_BASE_URL` | Origem autorizada para CORS (ex.: `http://localhost:3000`). |
-| `PORT` | Porta HTTP do backend (default `8080`). |
-| `JWT_SECRET` | Segredo para assinatura dos JWT. Gere ao menos 32 caracteres aleatórios. |
-| `JWT_EXPIRES_IN` / `JWT_REFRESH_EXPIRES_IN` | Duração dos tokens (formato `15m`, `7d`, ...). |
-| `ADMIN_EMAIL` / `ADMIN_PASSWORD_HASH` | Credenciais iniciais do administrador (hash BCrypt). |
-| `SHEETS_SPREADSHEET_ID` | ID da planilha Google Sheets criada. |
-| `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64` | JSON da Service Account em Base64. |
-| `ENCRYPTION_KEY` | Chave AES-256 (32 bytes Base64) usada para criptografar segredos de canais. |
-| `CACHE_TTL_SECONDS` | TTL do cache in-memory dos repositórios. |
-| `TZ` | Fuso horário padrão da aplicação/scheduler. |
-| `SCHEDULER_ENABLED` / `SCHEDULER_INTERVAL_MINUTES` | Ativa o worker. Para suportar horários diários personalizados o tick é fixo em 1 minuto (valores maiores são ignorados). |
-| `METRICS_ENABLED` | Expõe (`true`) ou oculta (`false`) o endpoint `/api/metrics`. |
-| `LOG_LEVEL` | Nível de log (ex.: `info`, `debug`). |
-| `RATE_LIMIT_TEST_WINDOW_MS` / `RATE_LIMIT_TEST_MAX` | Janela e limite para testes de canais (`/test`). |
-| `RATE_LIMIT_SENSITIVE_WINDOW_MS` / `RATE_LIMIT_SENSITIVE_MAX` | Janela e limite para endpoints sensíveis (`/test`, `/send`). |
-
-### Criptografia, backup e rotação
-- Segredos de canais são criptografados com AES-256-GCM (`backend/src/utils/crypto.ts`). Guarde `ENCRYPTION_KEY` de forma segura (ex.: cofre de segredos) e gere um backup offline.
-- Para rotacionar a chave de criptografia:
-  1. Gere uma nova chave Base64 de 32 bytes e atualize `ENCRYPTION_KEY`.
-  2. Escreva um script de migração (ou use o seed) para ler segredos existentes, descriptografar com a chave antiga e salvar com a nova.
-  3. Atualize o cofre/backup com a nova chave e destrua a anterior.
-- A mesma política vale para `JWT_SECRET` e `ADMIN_PASSWORD_HASH`: mantenha versões antigas apenas durante o período de transição e revogue acessos antigos.
-
-## Repositórios Google Sheets
-`backend/src/repositories/googleSheetsRepository.ts` encapsula toda a persistência (retry + cache). Endpoints da API não tocam diretamente o Sheets – utilize os serviços (`certificateService`, `channelService`, etc.) para garantir validações e auditoria.
-
-## Execução local (modo desenvolvimento)
-```bash
-# Backend
-cd backend
-cp .env.example .env   # preencha os valores
-npm install
-npm run dev
-
-# Frontend
-cd ../frontend
-cp .env.example .env
-npm install
-npm run dev
-```
-- Backend (API): http://localhost:8080
-- Frontend: http://localhost:5173
-
-## Docker Compose e health checks
-```bash
-docker compose up --build -d
-```
-Serviços:
-- `backend`: API com health check em `/api/health`.
-- `scheduler`: worker (`node dist/scheduler.js`) com heartbeat em `/tmp/scheduler-heartbeat.json` validado pelo health check.
-- `frontend`: UI servida por Nginx (porta 3000).
-
-Use `docker compose ps` para acompanhar o estado – os health checks garantirão que os containers só fiquem “healthy” após passarem nas verificações.
-
-## Criptografia e auditoria
-- Logs estruturados (Pino) são enviados para `stdout` em JSON, facilitando ingestão em sistemas de observabilidade.
-- `requestLogger` registra todas as requisições; erros passam por `errorHandler` (também estruturado).
-- Auditorias de ações (criação/atualização/testes) são salvas em `audit_logs` com o usuário autenticado.
-
-## Adicionando novos tipos de canal
-1. **Definição básica**: inclua o tipo em `CHANNEL_DEFINITIONS` (`backend/src/services/channelService.ts`) especificando parâmetros (`params`) e segredos (`secrets`).
-2. **Validação**: atualize `validateChannelParams`/`validateChannelSecret` com as regras específicas (URLs, portas, tokens, etc.) e, se necessário, ajuste `deliverMessage` para enviar a notificação.
-3. **Testes / Retry**: reutilize os utilitários existentes ou acrescente novos métodos `send*` no `ChannelService` para integrar com o serviço externo.
-4. **Frontend**: exponha os novos campos em `frontend/src/pages/ChannelsPage.tsx` e adapte `frontend/src/services/channels.ts` para enviar/formatar os parâmetros e segredos.
-5. **Documentação**: atualize o README descrevendo parâmetros obrigatórios, formato dos segredos e passos de teste.
-
-## Fluxo operacional (canal → teste → vincular → disparo)
-1. **Criar canal**: preencha nome, tipo, parâmetros e segredos no frontend. O backend valida URLs, portas e e-mails antes de salvar.
-2. **Testar canal**: use o botão "Testar". O rate limit evita abuso (configurável via `RATE_LIMIT_*`).
-3. **Vincular a certificados**: em “Certificados”, associe os canais ativos ao certificado desejado.
-4. **Disparo de alertas**:
-   - Manual: botão “Enviar notificação de teste” (`/certificates/:id/test-notification`).
-   - Automático: scheduler avalia o vencimento via `AlertSchedulerJob` e registra auditoria para cada envio.
-
-## Próximos passos sugeridos
-- Evoluir a UI para gerenciamento completo de canais/segredos.
-- Integrar autenticação multiusuário real (a base para auditoria já existe).
-- Implementar testes de integração para os repositórios (Google Sheets).
-- Acrescentar observabilidade (dashboards/alerts) consumindo os logs JSON e métricas.
+> Persistindo algum problema, consulte os logs dos containers (`docker compose logs <serviço> -f`) para detalhes adicionais.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,38 +1,20 @@
-# Backend HTTP configuration
-APP_BASE_URL=http://localhost:3000
-PORT=8080
-NODE_ENV=development
+# APP_BASE_URL: origem autorizada para o frontend consumir a API.
+APP_BASE_URL=
 
-# Authentication
-JWT_SECRET=replace-with-random-secret
-JWT_EXPIRES_IN=15m
-JWT_REFRESH_EXPIRES_IN=7d
-JWT_COOKIE_SAMESITE=lax
-ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD_HASH=$2a$10$exampleHashValueReplace
+# JWT_SECRET: segredo de alta entropia para assinar tokens.
+JWT_SECRET=
 
-# Google Sheets integration
-SHEETS_SPREADSHEET_ID=your-spreadsheet-id
-GOOGLE_SERVICE_ACCOUNT_JSON_BASE64=base64-encoded-service-account-json
+# ADMIN_EMAIL: e-mail do usuário administrador inicial.
+ADMIN_EMAIL=
 
-# Scheduler & timezone
-SCHEDULER_ENABLED=true
-SCHEDULER_INTERVAL_MINUTES=1
-TZ=America/Fortaleza
+# ADMIN_PASSWORD_HASH: hash BCrypt da senha inicial do administrador.
+ADMIN_PASSWORD_HASH=
 
-# Encryption & cache
-ENCRYPTION_KEY=base64-32-bytes-key
-CACHE_TTL_SECONDS=60
+# GOOGLE_SERVICE_ACCOUNT_JSON_BASE64: chave JSON da Service Account codificada em Base64.
+GOOGLE_SERVICE_ACCOUNT_JSON_BASE64=
 
-# Metrics & logging
-METRICS_ENABLED=true
-LOG_LEVEL=info
+# SHEETS_SPREADSHEET_ID: identificador da planilha usada como banco.
+SHEETS_SPREADSHEET_ID=
 
-# Rate limiting
-RATE_LIMIT_GLOBAL_WINDOW_MS=60000
-RATE_LIMIT_GLOBAL_MAX=300
-RATE_LIMIT_TEST_WINDOW_MS=60000
-RATE_LIMIT_TEST_MAX=5
-RATE_LIMIT_SENSITIVE_WINDOW_MS=60000
-RATE_LIMIT_SENSITIVE_MAX=10
-
+# ENCRYPTION_KEY: chave AES-256 (Base64) para cifrar segredos de canais.
+ENCRYPTION_KEY=


### PR DESCRIPTION
## Resumo
- Reestruturei o README com visão geral, pré-requisitos e passos detalhados para configurar o Google Sheets, gerar variáveis obrigatórias e operar a stack.
- Documentei variáveis opcionais com seus defaults e acrescentei seções de execução, rotação de chaves, segurança e troubleshooting.
- Reduzi o `.env.example` do backend para conter apenas as variáveis principais obrigatórias.

## Testes
- Não foram necessários testes automatizados (alterações apenas de documentação).


------
https://chatgpt.com/codex/tasks/task_e_68dc56e491808330bad72d7ff6772604